### PR TITLE
Add LocationRepository to encapsulate database operations

### DIFF
--- a/packages/server/src/db.js
+++ b/packages/server/src/db.js
@@ -5,4 +5,22 @@ const knexfile = require('../db/knexfile');
 
 const knex = Knex(knexfile.development);
 
-module.exports = knex;
+class LocationRepository {
+  static async getLocations() {
+    return knex.select().from('locations');
+  }
+
+  static async addLocation(payload) {
+    return knex('locations').insert({
+      lat: payload.lat,
+      lon: payload.lon,
+    });
+  }
+
+  static async latestLocation() {
+    return knex.select().from('locations').orderBy('created_at', 'desc').limit(1);
+  }
+}
+
+
+module.exports = LocationRepository;

--- a/packages/server/src/db.js
+++ b/packages/server/src/db.js
@@ -22,5 +22,4 @@ class LocationRepository {
   }
 }
 
-
 module.exports = LocationRepository;

--- a/packages/server/src/endpoints/locations.js
+++ b/packages/server/src/endpoints/locations.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const db = require('../db');
 const Joi = require('@hapi/joi');
+const Repo = require('../db');
 
 const getLocations = {
   method: 'GET',
@@ -23,8 +23,7 @@ const getLocations = {
     },
   },
   async handler() {
-    const locations = await db.select().from('locations');
-    return locations;
+    return Repo.getLocations();
   },
 };
 
@@ -41,10 +40,7 @@ const postLocation = {
     },
   },
   async handler({ payload }, h) {
-    await db('locations').insert({
-      lat: payload.lat,
-      lon: payload.lon,
-    });
+    await Repo.addLocation(payload);
 
     return h.response().code(201);
   },


### PR DESCRIPTION
This pull request adds a `LocationRepository` for encapsulating all the database operations for `locations`. I added an unused `latestLocation()` method that will be used in future pull requests for determining the status of the gnome.