### PR TITLE
Quick example using rethinkdb

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,6 +19,7 @@
     "nodemon": "^1.18.11",
     "objection": "^1.6.8",
     "pg": "^7.10.0",
+    "rethinkdb": "^2.3.3",
     "vision": "^5.4.4"
   },
   "devDependencies": {

--- a/packages/server/rdb/setup.js
+++ b/packages/server/rdb/setup.js
@@ -1,0 +1,19 @@
+const r = require('rethinkdb');
+
+const setupDb = async () => {
+  const conn = await r.connect();
+  const dbs = await r.dbList().run(conn);
+
+  if (dbs.includes('galavanting_gnome_dev')) {
+    await r.dbDrop('galavanting_gnome_dev').run(conn);
+    console.log('Dropped galavanting_gnome_dev');
+  }
+
+  await r.dbCreate('galavanting_gnome_dev').run(conn);
+  await r.db('galavanting_gnome_dev').tableCreate('locations').run(conn);
+
+  console.log('Created galavanting_gnome_dev');
+  await conn.close();
+};
+
+setupDb();

--- a/packages/server/src/endpoints/locations.js
+++ b/packages/server/src/endpoints/locations.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Joi = require('@hapi/joi');
-const db = require('../db');
+const r = require('rethinkdb');
 
 const getLocations = {
   method: 'GET',
@@ -23,8 +23,10 @@ const getLocations = {
     },
   },
   async handler() {
-    // need to make seed data have different times
-    const locations = await db.select().from('locations').orderBy('id', 'desc');
+    const conn = await r.connect({ db: 'galavanting_gnome_dev' });
+    const locations = await r.table('locations').coerceTo('array').run(conn);
+    await conn.close();
+
     return locations;
   },
 };
@@ -42,10 +44,9 @@ const postLocation = {
     },
   },
   async handler({ payload }, h) {
-    await db('locations').insert({
-      lat: payload.lat,
-      lon: payload.lon,
-    });
+    const conn = await r.connect({ db: 'galavanting_gnome_dev' });
+    await r.table('locations').insert(payload).run(conn);
+    await conn.close();
 
     return h.response().code(201);
   },

--- a/packages/server/yarn.lock
+++ b/packages/server/yarn.lock
@@ -681,6 +681,11 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
+"bluebird@>= 2.3.2 < 3":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
+  integrity sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=
+
 bluebird@^3.5.3, bluebird@^3.5.4:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.4.tgz#d6cc661595de30d5b3af5fcedd3c0b3ef6ec5714"
@@ -4339,6 +4344,13 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
+
+rethinkdb@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/rethinkdb/-/rethinkdb-2.3.3.tgz#3dc6586e22fa1dabee0d254e64bd0e379fad2f72"
+  integrity sha1-PcZYbiL6HavuDSVOZL0ON5+tL3I=
+  dependencies:
+    bluebird ">= 2.3.2 < 3"
 
 rimraf@2.6.3, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3:
   version "2.6.3"


### PR DESCRIPTION
This is a small example using RethinkDB instead of Postgres with Knex.

I'm interested in rethink because it seems a bit like Firestore but less shit. I thought this example was really easy to get going, especially the setup script.

Major reservations about it due to the NPM package not being updated in 3 years. The project itself has small (seemingly responsive) development, and is working to a 2.4 release. It seems like they want to continue development on it, but there's not a big community and not a lot of funds, so lots of people are asking or think it's dead.
Though part of me thinks that adding a project that uses it, and us talking about it would help keep it alive. Plus this more or less has an end date, so it's not like we'd be too invested in it anyway.

I also don't know how this would affect deployment. I think I could stand a bit of configuration, but if it's very hands-on for setup and maintenance then I wouldn't want to use it.

A fairer example would need to look into writing a test to see how that goes, and abstracting the connection creation and closing.
The example projects use Express so create and close the connection in middleware. There should be equivalents in Hapi.