### PR TITLE
Check distance before publishing location

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@hapi/joi": "^15.0.2",
+    "geolib": "^3.0.3",
     "hapi": "^18.1.0",
     "hapi-swagger": "^9.4.2",
     "inert": "^5.1.3",

--- a/packages/server/src/services/location-service.js
+++ b/packages/server/src/services/location-service.js
@@ -16,8 +16,7 @@ const LocationService = {
     return db.transaction(async (tx) => {
       const unpublishedLocations = await tx('locations')
         .select('id', 'lat', 'lon')
-        .whereNull('published_at')
-        .orderBy('published_at', 'desc');
+        .whereNull('published_at');
 
       const locationIdsToPublish = unpublishedLocations.reduce((locations, unpublishedLocation) => {
         if (this.canPublishLocation(props, unpublishedLocation)) {

--- a/packages/server/src/services/location-service.js
+++ b/packages/server/src/services/location-service.js
@@ -14,15 +14,16 @@ const LocationService = {
 
   async addLocation(props) {
     return db.transaction(async (tx) => {
-      const lastLocation = await tx('locations')
+      const unpublishedLocations = await tx('locations')
         .select('id', 'lat', 'lon')
         .whereNull('published_at')
-        .orderBy('created_at', 'desc')
-        .first();
+        .orderBy('published_at', 'desc');
 
-      if (this.canPublishLocation(props, lastLocation)) {
-        await tx('locations').update('published_at', new Date()).where(lastLocation);
-      }
+      unpublishedLocations.forEach(async (unpublishedLocation) => {
+        if (this.canPublishLocation(props, unpublishedLocation)) {
+          await tx('locations').update('published_at', new Date()).where(unpublishedLocation);
+        }
+      });
 
       return tx('locations').insert({
         ...props,

--- a/packages/server/src/services/location-service.js
+++ b/packages/server/src/services/location-service.js
@@ -19,11 +19,15 @@ const LocationService = {
         .whereNull('published_at')
         .orderBy('published_at', 'desc');
 
-      unpublishedLocations.forEach(async (unpublishedLocation) => {
+      const locationIdsToPublish = unpublishedLocations.reduce((locations, unpublishedLocation) => {
         if (this.canPublishLocation(props, unpublishedLocation)) {
-          await tx('locations').update('published_at', new Date()).where(unpublishedLocation);
+          return locations.concat(unpublishedLocation.id);
         }
-      });
+
+        return locations;
+      }, []);
+
+      await tx('locations').update('published_at', new Date()).whereIn('id', locationIdsToPublish);
 
       return tx('locations').insert({
         ...props,

--- a/packages/server/src/services/location-service.js
+++ b/packages/server/src/services/location-service.js
@@ -1,8 +1,11 @@
 'use strict';
 
+const { getDistance } = require('geolib');
 const db = require('../db');
 
 const LocationService = {
+  MIN_DISTANCE_METERS: 100,
+
   async getLocations() {
     // need to make seed data have different times
     const locations = await db.select().from('locations').orderBy('id', 'desc');
@@ -12,12 +15,12 @@ const LocationService = {
   async addLocation(props) {
     return db.transaction(async (tx) => {
       const lastLocation = await tx('locations')
-        .select('id')
+        .select('id', 'lat', 'lon')
         .whereNull('published_at')
         .orderBy('created_at', 'desc')
         .first();
 
-      if (lastLocation) {
+      if (this.canPublishLocation(props, lastLocation)) {
         await tx('locations').update('published_at', new Date()).where(lastLocation);
       }
 
@@ -26,6 +29,23 @@ const LocationService = {
         published_at: null,
       }).returning('id');
     });
+  },
+
+  canPublishLocation(newLocation, previousLocation) {
+    if (!previousLocation) {
+      return false;
+    }
+
+    const distance = getDistance(
+      { latitude: newLocation.lat, longitude: newLocation.lon },
+      { latitude: previousLocation.lat, longitude: previousLocation.lon },
+    );
+
+    if (distance < this.MIN_DISTANCE_METERS) {
+      return false;
+    }
+
+    return true;
   },
 };
 

--- a/packages/server/src/services/location-service.test.js
+++ b/packages/server/src/services/location-service.test.js
@@ -44,5 +44,21 @@ describe('LocationService', () => {
       expect(prevLocation.published_at).not.toBeFalsy();
       expect(newLocation.published_at).toBeFalsy();
     });
+
+    it('should not publish the previous location if the new location is not far away enough', async () => {
+      const location = {
+        lat: 0,
+        lon: 0,
+        kph: 0,
+        heading: 0,
+        alt: 0,
+      };
+      const [prevLocationId] = await db('locations').insert(location).returning('id');
+      await LocationService.addLocation(location);
+
+      const [prevLocation] = await db('locations').select('published_at').where('id', prevLocationId);
+
+      expect(prevLocation.published_at).toBeFalsy();
+    });
   });
 });

--- a/packages/server/src/services/location-service.test.js
+++ b/packages/server/src/services/location-service.test.js
@@ -60,5 +60,33 @@ describe('LocationService', () => {
 
       expect(prevLocation.published_at).toBeFalsy();
     });
+
+    it('should publish all unpublished locations until it hits one that is not far enough away', async () => {
+      const baseLocation = {
+        lat: 0,
+        lon: 0,
+        kph: 0,
+        heading: 0,
+        alt: 0,
+      };
+
+      const [firstLocationId, secondLocationId, thirdLocationId] = await db('locations')
+        .insert([
+          { ...baseLocation },
+          { ...baseLocation },
+          { ...baseLocation, lon: 0.0005 }, // 56 meters from 0
+        ])
+        .returning('id');
+
+      await LocationService.addLocation({ ...baseLocation, lon: 0.001 }); // 111 meters from 0
+
+      const [firstLocation] = await db('locations').select('published_at').where('id', firstLocationId);
+      const [secondLocation] = await db('locations').select('published_at').where('id', secondLocationId);
+      const [thirdLocation] = await db('locations').select('published_at').where('id', thirdLocationId);
+
+      expect(firstLocation.published_at).toBeTruthy();
+      expect(secondLocation.published_at).toBeTruthy();
+      expect(thirdLocation.published_at).toBeFalsy();
+    });
   });
 });

--- a/packages/server/yarn.lock
+++ b/packages/server/yarn.lock
@@ -1760,6 +1760,11 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
+geolib@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/geolib/-/geolib-3.0.3.tgz#cc1d3818cd961cdb4a4f9af3b34a68169e6ffde5"
+  integrity sha512-cBYgFS0bfMOCEXEvf2RbxWOo602B878aOGNtAARoBNHHC++4CNZICfp8+4g2/uol1VHXaKhrrPpnUA/ixO2Hbg==
+
 get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"


### PR DESCRIPTION
These changes should make it so when a location is added, the previous location isn't published until it's far enough away.

I decided that far enough away would be 100 meters. I don't imagine it'd unintentionally move more than that unless the warm up for the GPS is way too off (assuming it'll be starting cold).

My intention is going to be to make it so it does things on a timeline like this

1. add location X1, Y1 at 12:00
2. add location X2, Y2 at 12:30
3. The distance between the first and second location is less than 100m, so the first location is not published
4. add location X3, Y3 at 13:00
5. The distance between the first and third location is greater than 100m, so the first location is published
6. The distance between the second location and the third location is greater than 100m, so the second is published

Closes #4 