### PR TITLE
Add support for the Pro Mini

### DIFF
--- a/packages/firmware/platformio.ini
+++ b/packages/firmware/platformio.ini
@@ -34,6 +34,30 @@ lib_deps =
 build_flags =
     -DGNOME_DEBUG
 
+[env:pro]
+platform = atmelavr
+board = pro8MHzatmega328
+framework = arduino
+lib_deps =
+    634
+    136@1.5.0
+    Wire
+    ArduinoJson
+    Automaton
+
+[env:pro_debug]
+platform = atmelavr
+board = pro8MHzatmega328
+framework = arduino
+lib_deps =
+    634
+    136@1.5.0
+    Wire
+    ArduinoJson
+    Automaton
+build_flags =
+    -DGNOME_DEBUG
+
 [env:uno]
 platform = atmelavr
 board = uno


### PR DESCRIPTION
Add support for the Arduino Pro Mini. This will likely be the only supported board, since it runs on 3.3V which works better with the battery.